### PR TITLE
feat: refactor producer batching with timeout supported

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ env_logger = "^0.11.8"
 serde = { version = "^1.0.216", features = ["derive"] }
 serde_json = "^1.0.133"
 tokio = { version = "^1.42.0", features = ["macros", "rt-multi-thread"] }
+assert_matches = "1.5.0"
 
 [build-dependencies]
 prost-build = "^0.13.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -286,6 +286,8 @@ pub enum ProducerError {
     /// Indicates this producer has lost exclusive access to the topic. Client can decided whether
     /// to recreate or not
     Fenced,
+    /// Indicates the producer is closed or dropped
+    Closed,
 }
 
 impl From<ConnectionError> for ProducerError {
@@ -333,6 +335,7 @@ impl fmt::Display for ProducerError {
                 Ok(())
             }
             ProducerError::Fenced => write!(f, "Producer is fenced"),
+            ProducerError::Closed => write!(f, "Producer is closed or dropped"),
         }
     }
 }
@@ -359,6 +362,7 @@ impl fmt::Debug for ProducerError {
                 write!(f, ")")
             }
             ProducerError::Fenced => write!(f, "Producer is fenced"),
+            ProducerError::Closed => write!(f, "Producer is closed or dropped"),
         }
     }
 }
@@ -376,6 +380,7 @@ impl std::error::Error for ProducerError {
                 .map(|r| r.as_ref().map(drop).unwrap_err() as _),
             ProducerError::Custom(_) => None,
             ProducerError::Fenced => None,
+            ProducerError::Closed => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,15 +621,13 @@ mod tests {
         let _ = producer.close().await;
         let error = producer.send_batch().await.err().unwrap();
         info!("send_batch failed: {}", &error);
-        if let PulsarError::Producer(ProducerError::Custom(msg)) = error {
-            assert!(msg.contains("send failed because receiver is gone"));
+        if let PulsarError::Producer(ProducerError::Fenced) = error {
         } else {
             panic!();
         }
         let error = producer.send_non_blocking("msg").await.err().unwrap();
         info!("send failed: {error}");
-        if let PulsarError::Producer(ProducerError::Custom(msg)) = error {
-            assert!(msg.contains("send failed because receiver is gone"));
+        if let PulsarError::Producer(ProducerError::Fenced) = error {
         } else {
             panic!();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,6 +615,16 @@ mod tests {
             get_send_msg_ids(send_futures).await,
             vec![(7, 0, 2), (7, 1, 2)]
         );
+
+        // Test send_batch after close
+        let _ = producer.close().await;
+        assert!(producer
+            .send_non_blocking("msg")
+            .await
+            .unwrap()
+            .await
+            .is_err());
+        assert!(producer.send_batch().await.is_err());
     }
 
     async fn get_send_msg_ids(send_futures: Vec<SendFuture>) -> Vec<(u64, i32, i32)> {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -571,6 +571,7 @@ impl<Exe: Executor> TopicProducer<Exe> {
             let executor_clone = executor.clone();
             let (batch_sender, batch_receiver) = mpsc::channel::<Vec<SingleMessage>>(1);
             let _ = executor.spawn(Box::pin(batch_process_loop(
+                producer_id,
                 batch_storage,
                 receiver,
                 batch_sender,
@@ -1015,6 +1016,7 @@ type SingleMessage = (
 );
 
 async fn batch_process_loop(
+    producer_id: ProducerId,
     mut batch_storage: BatchStorage,
     mut msg_receiver: mpsc::Receiver<Option<SingleMessage>>,
     batch_sender: mpsc::Sender<Vec<SingleMessage>>,
@@ -1050,7 +1052,7 @@ async fn batch_process_loop(
                 }
             },
             Either::Left((None, _)) => {
-                debug!("batch_process_loop: channel closed, exiting");
+                debug!("{producer_id} batch_process_loop: channel closed, exiting");
                 break;
             }
             Either::Right((_, previous_recv_future)) => {
@@ -1142,7 +1144,7 @@ async fn message_send_loop<Exe>(
                 };
             }
             None => {
-                debug!("message_send_loop: channel closed, exiting");
+                debug!("{producer_id} message_send_loop: channel closed, exiting");
                 break;
             }
         }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -683,7 +683,11 @@ impl<Exe: Executor> TopicProducer<Exe> {
                     },
                     payload: message.payload,
                 };
-                let _ = sender.send(Some((tx, batched))).await;
+                sender.send(Some((tx, batched))).await.map_err(|e| {
+                    Error::Producer(ProducerError::Custom(format!(
+                        "failed to send message to batch_process_loop: {e}"
+                    )))
+                })?;
             }
         };
         Ok(SendFuture(rx))

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -629,10 +629,10 @@ impl<Exe: Executor> TopicProducer<Exe> {
     async fn send_batch(&mut self) -> Result<(), Error> {
         match &mut self.batch_msg_sender {
             None => Err(ProducerError::Custom("not a batching producer".to_string()).into()),
-            Some(sender) => sender.send(None).await.map_err(|_| {
-                Error::Producer(ProducerError::Custom(
-                    "could not send batch trigger to batch task".to_string(),
-                ))
+            Some(sender) => sender.send(None).await.map_err(|e| {
+                Error::Producer(ProducerError::Custom(format!(
+                    "could not trigger send_batch to batch task: {e}"
+                )))
             }),
         }
     }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1042,10 +1042,7 @@ impl BatchStorage {
                 return true;
             }
         }
-        match self.storage.back() {
-            Some(BatchItem::Flush(_)) => return true,
-            _ => false,
-        }
+        matches!(self.storage.back(), Some(BatchItem::Flush(_)))
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/streamnative/pulsar-rs/issues/306

### Motivation

Without batching timeout, the batching feature will be hard to use because the messages won't be sent if the size of byte size limit is not reached. Users can call `send_batch` to flush all messages, but awaiting this method will wait until the batched send is done. Without awaiting `send_batch`, the producer will be borrowed and cannot send next message.

In addition, the current batching implementation has some minor issues:
- The returned message id by `send_non_blocking` does not have batch index set
- If `batch_size` is not set, even if `max_byte_size` is set, the message won't be batched.

### Modifications

Add a producer new option `batch_timeout` to specify whether to enable the batch timeout. Refactor the implementation with the message delivery based design. When batching is enabled, create two tasks:
1. `batch_process_loop`
   - Receive all single messages (*) from the producer and add them to batch and flush the batch (all messages in the `BatchStorage`) as a whole to `message_send_loop`
   - If batch timeout is configured, when the 1st message is added, start a delayed task with the given timeout. If the timeout is reached first, flush the messages regardless of the size limit.
2. `message_send_loop`: receive batches and send batches to broker one by one

A single messages is composed of an `oneshot::Sender` and a message (`BatchedMessage`). The future returned by `send_non_blocking(...).await` is the `oneshot::Receiver` associated to that sender. When `send_non_blocking` is called, create an `oneshot::channel` and return the receiver as the send future. The sender and the user provided message will be wrapped to a `SingleMessage` and then sent to `batch_process_loop`.

Specifically, when `send_batch` is called, send only a `oneshot::Sender` to the `batch_process_loop` to flush existing messages and wait the result in `send_batch`.

Handle closing producer carefully by closing the sender to trigger the exit of `batch_process_loop`. When it exits, fail all pending sends with a newly added error code `ProducerError::Closed`.

### Tests

Improve `batching` to cover various cases:
1. Only `batch_size` is set.
2. Only `batch_byte_size` is set.
3. Only `batch_timeout` is set.
4. All these configs are set.

Add a new `flush` test to cover the semantic of `send_batch` and the behavior after closing the producer.