### PR TITLE
Allow to change rustls crypto provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ crc = "^3.3.0"
 data-url = { version = "^0.3.1", optional = true }
 flate2 = { version = "^1.1.1", optional = true }
 futures = "^0.3.31"
-futures-rustls = { version = "^0.26.0", optional = true } # replacement of crate async-rustls (also a fork of tokio-rustls)
+futures-rustls = { version = "^0.26.0", default-features = false, features = ["tls12", "logging"], optional = true } # replacement of crate async-rustls (also a fork of tokio-rustls)
 log = "^0.4.27"
 lz4 = { version = "^1.28.0", optional = true }
 native-tls = { version = "^0.2.12", optional = true }
@@ -39,13 +39,13 @@ prost = "^0.13.4"
 prost-derive = "^0.13.4"
 rand = "^0.8.5"
 regex = "^1.11.1"
-rustls = { version = "^0.23.27", optional = true }
+rustls = { version = "^0.23.27", default-features = false, features = ["log", "std"] , optional = true }
 snap = { version = "^1.1.1", optional = true }
 serde = { version = "^1.0.219", features = ["derive"], optional = true }
 serde_json = { version = "^1.0.140", optional = true }
 tokio = { version = "^1.45.0", features = ["rt", "net", "time"], optional = true }
 tokio-util = { version = "^0.7.15", features = ["codec"], optional = true }
-tokio-rustls = { version = "0.26.2", optional = true }
+tokio-rustls = { version = "0.26.2", default-features = false, features = ["logging", "tls12"], optional = true }
 tokio-native-tls = { version = "^0.3.1", optional = true }
 tracing = { version = "^0.1.41", optional = true }
 url = "^2.5.4"
@@ -67,11 +67,15 @@ protobuf-src = { version = "^2.1.0", optional = true }
 
 [features]
 async-std-runtime = ["async-std", "asynchronous-codec", "native-tls", "async-native-tls"]
-async-std-rustls-runtime = ["async-std", "asynchronous-codec", "futures-rustls", "rustls", "webpki-roots"]
+async-std-rustls-runtime = ["async-std-rustls-runtime-aws-lc-rs"]
+async-std-rustls-runtime-aws-lc-rs = ["async-std", "asynchronous-codec", "webpki-roots", "rustls/aws-lc-rs", "futures-rustls/aws-lc-rs"]
+async-std-rustls-runtime-ring = ["async-std", "asynchronous-codec", "webpki-roots", "rustls/ring", "futures-rustls/ring"]
 auth-oauth2 = ["openidconnect", "oauth2", "serde", "serde_json", "data-url"]
 compression = ["lz4", "flate2", "zstd", "snap"]
 default = ["compression", "tokio-runtime", "async-std-runtime", "auth-oauth2"]
 protobuf-src = ["dep:protobuf-src"]
 telemetry = ["tracing"]
 tokio-runtime = ["tokio", "tokio-util", "native-tls", "tokio-native-tls"]
-tokio-rustls-runtime = ["tokio", "tokio-util", "tokio-rustls", "rustls", "webpki-roots"]
+tokio-rustls-runtime = ["tokio-rustls-runtime-aws-lc-rs"]
+tokio-rustls-runtime-aws-lc-rs = ["tokio", "tokio-util", "webpki-roots", "rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
+tokio-rustls-runtime-ring = ["tokio", "tokio-util", "webpki-roots", "rustls/ring", "tokio-rustls/ring"]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1010,7 +1010,13 @@ impl<Exe: Executor> Connection<Exe> {
                     .await
                 }
             }
-            #[cfg(all(feature = "tokio-rustls-runtime", not(feature = "tokio-runtime")))]
+            #[cfg(all(
+                any(
+                    feature = "tokio-rustls-runtime-aws-lc-rs",
+                    feature = "tokio-rustls-runtime-ring"
+                ),
+                not(feature = "tokio-runtime")
+            ))]
             ExecutorKind::Tokio => {
                 if tls {
                     let stream = tokio::net::TcpStream::connect(&address).await?;
@@ -1061,7 +1067,11 @@ impl<Exe: Executor> Connection<Exe> {
                     .await
                 }
             }
-            #[cfg(all(not(feature = "tokio-runtime"), not(feature = "tokio-rustls-runtime")))]
+            #[cfg(all(
+                not(feature = "tokio-runtime"),
+                not(feature = "tokio-rustls-runtime-aws-lc-rs"),
+                not(feature = "tokio-rustls-runtime-ring")
+            ))]
             ExecutorKind::Tokio => {
                 unimplemented!("the tokio-runtime cargo feature is not active");
             }
@@ -1110,7 +1120,10 @@ impl<Exe: Executor> Connection<Exe> {
                 }
             }
             #[cfg(all(
-                feature = "async-std-rustls-runtime",
+                any(
+                    feature = "async-std-rustls-runtime-aws-lc-rs",
+                    feature = "async-std-rustls-runtime-ring"
+                ),
                 not(feature = "async-std-runtime")
             ))]
             #[allow(deprecated)]
@@ -1166,7 +1179,8 @@ impl<Exe: Executor> Connection<Exe> {
             }
             #[cfg(all(
                 not(feature = "async-std-runtime"),
-                not(feature = "async-std-rustls-runtime")
+                not(feature = "async-std-rustls-runtime-aws-lc-rs"),
+                not(feature = "async-std-rustls-runtime-ring")
             ))]
             ExecutorKind::AsyncStd => {
                 unimplemented!("the async-std-runtime cargo feature is not active");
@@ -1811,7 +1825,11 @@ mod tests {
     use uuid::Uuid;
 
     use super::{Connection, Receiver};
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     use crate::TokioExecutor;
     use crate::{
         authentication::Authentication,
@@ -1821,7 +1839,11 @@ mod tests {
     };
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn receiver_auth_challenge_test() {
         let (message_tx, message_rx) = mpsc::unbounded();
         let (tx, _) = async_channel::bounded(10);
@@ -1879,7 +1901,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn connection_auth_challenge_test() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
 

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -211,8 +211,10 @@ impl<Exe: Executor> ConnectionManager<Exe> {
 
                     #[cfg(all(
                         any(
-                            feature = "tokio-rustls-runtime",
-                            feature = "async-std-rustls-runtime"
+                            feature = "tokio-rustls-runtime-aws-lc-rs",
+                            feature = "tokio-rustls-runtime-ring",
+                            feature = "async-std-rustls-runtime-aws-lc-rs",
+                            feature = "async-std-rustls-runtime-ring"
                         ),
                         not(any(feature = "tokio-runtime", feature = "async-std-runtime"))
                     ))]

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -437,11 +437,19 @@ mod tests {
     };
     use log::LevelFilter;
     use regex::Regex;
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     use tokio::time::timeout;
 
     use super::*;
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     use crate::executor::TokioExecutor;
     use crate::{
         consumer::initial_position::InitialPosition, producer, proto, tests::TEST_LOGGER,
@@ -493,7 +501,11 @@ mod tests {
         tag: "multi_consumer",
     };
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn multi_consumer() {
         let _result = log::set_logger(&MULTI_LOGGER);
         log::set_max_level(LevelFilter::Debug);
@@ -584,7 +596,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn consumer_dropped_with_lingering_acks() {
         use rand::{distributions::Alphanumeric, Rng};
         let _result = log::set_logger(&TEST_LOGGER);
@@ -681,7 +697,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn dead_letter_queue() {
         let _result = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Debug);
@@ -761,7 +781,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn dead_letter_queue_batched() {
         use crate::ProducerOptions;
 
@@ -860,7 +884,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn failover() {
         let _result = log::set_logger(&MULTI_LOGGER);
         log::set_max_level(LevelFilter::Debug);
@@ -920,7 +948,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn seek_single_consumer() {
         let _result = log::set_logger(&MULTI_LOGGER);
         log::set_max_level(LevelFilter::Debug);
@@ -1031,7 +1063,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn schema_test() {
         #[derive(Serialize, Deserialize)]
         struct TestData {

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,11 +92,21 @@ pub enum ConnectionError {
     #[cfg(any(feature = "tokio-runtime", feature = "async-std-runtime"))]
     Tls(native_tls::Error),
     #[cfg(all(
-        any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"),
+        any(
+            feature = "tokio-rustls-runtime-aws-lc-rs",
+            feature = "tokio-rustls-runtime-ring",
+            feature = "async-std-rustls-runtime-aws-lc-rs",
+            feature = "async-std-rustls-runtime-ring",
+        ),
         not(any(feature = "tokio-runtime", feature = "async-std-runtime"))
     ))]
     Tls(rustls::Error),
-    #[cfg(any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring",
+        feature = "async-std-rustls-runtime-aws-lc-rs",
+        feature = "async-std-rustls-runtime-ring",
+    ))]
     DnsName(rustls::pki_types::InvalidDnsNameError),
     Authentication(AuthenticationError),
     NotFound,
@@ -131,7 +141,12 @@ impl From<native_tls::Error> for ConnectionError {
 }
 
 #[cfg(all(
-    any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"),
+    any(
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring",
+        feature = "async-std-rustls-runtime-aws-lc-rs",
+        feature = "async-std-rustls-runtime-ring",
+    ),
     not(any(feature = "tokio-runtime", feature = "async-std-runtime"))
 ))]
 impl From<rustls::Error> for ConnectionError {
@@ -141,7 +156,12 @@ impl From<rustls::Error> for ConnectionError {
     }
 }
 
-#[cfg(any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"))]
+#[cfg(any(
+    feature = "tokio-rustls-runtime-aws-lc-rs",
+    feature = "tokio-rustls-runtime-ring",
+    feature = "async-std-rustls-runtime-aws-lc-rs",
+    feature = "async-std-rustls-runtime-ring",
+))]
 impl From<rustls::pki_types::InvalidDnsNameError> for ConnectionError {
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn from(err: rustls::pki_types::InvalidDnsNameError) -> Self {
@@ -188,7 +208,12 @@ impl fmt::Display for ConnectionError {
             ConnectionError::Encoding(e) => write!(f, "Error encoding message: {e}"),
             ConnectionError::SocketAddr(e) => write!(f, "Error obtaining socket address: {e}"),
             ConnectionError::Tls(e) => write!(f, "Error connecting TLS stream: {e}"),
-            #[cfg(any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"))]
+            #[cfg(any(
+                feature = "tokio-rustls-runtime-aws-lc-rs",
+                feature = "tokio-rustls-runtime-ring",
+                feature = "async-std-rustls-runtime-aws-lc-rs",
+                feature = "async-std-rustls-runtime-ring",
+            ))]
             ConnectionError::DnsName(e) => write!(f, "Error resolving hostname: {e}"),
             ConnectionError::Authentication(e) => write!(f, "Error authentication: {e}"),
             ConnectionError::UnexpectedResponse(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,10 +160,30 @@ extern crate prost_derive;
 #[macro_use]
 extern crate serde;
 
-#[cfg(all(feature = "tokio-rustls-runtime", feature = "tokio-runtime"))]
-compile_error!("You have selected both features \"tokio-rustls-runtime\" and \"tokio-runtime\" which are exclusive, please choose one of them");
-#[cfg(all(feature = "async-std-rustls-runtime", feature = "async-std-runtime"))]
-compile_error!("You have selected both features \"async-std-rustls-runtime\" and \"async-std-runtime\" which are exclusive, please choose one of them");
+#[cfg(all(feature = "tokio-rustls-runtime-aws-lc-rs", feature = "tokio-runtime"))]
+compile_error!("You have selected both features \"tokio-rustls-runtime-aws-lc-rs\" and \"tokio-runtime\" which are exclusive, please choose one of them");
+#[cfg(all(feature = "tokio-rustls-runtime-ring", feature = "tokio-runtime"))]
+compile_error!("You have selected both features \"tokio-rustls-runtime-ring\" and \"tokio-runtime\" which are exclusive, please choose one of them");
+#[cfg(all(
+    feature = "tokio-rustls-runtime-aws-lc-rs",
+    feature = "tokio-rustls-runtime-ring"
+))]
+compile_error!("You have selected both features \"tokio-rustls-runtime-aws-lc-rs\" and \"tokio-rustls-runtime-ring\" which are exclusive, please choose one of them");
+#[cfg(all(
+    feature = "async-std-rustls-runtime-aws-lc-rs",
+    feature = "async-std-runtime"
+))]
+compile_error!("You have selected both features \"async-std-rustls-runtime-aws-lc-rs\" and \"async-std-runtime\" which are exclusive, please choose one of them");
+#[cfg(all(
+    feature = "async-std-rustls-runtime-ring",
+    feature = "async-std-runtime"
+))]
+compile_error!("You have selected both features \"async-std-rustls-runtime-ring\" and \"async-std-runtime\" which are exclusive, please choose one of them");
+#[cfg(all(
+    feature = "async-std-rustls-runtime-aws-lc-rs",
+    feature = "async-std-rustls-runtime-ring"
+))]
+compile_error!("You have selected both features \"async-std-rustls-runtime-aws-lc-rs\" and \"async-std-rustls-runtime-ring\" which are exclusive, please choose one of them");
 
 pub use client::{DeserializeMessage, Pulsar, PulsarBuilder, SerializeMessage};
 pub use connection::Authentication;
@@ -172,10 +192,18 @@ pub use connection_manager::{
 };
 pub use consumer::{Consumer, ConsumerBuilder, ConsumerOptions};
 pub use error::Error;
-#[cfg(any(feature = "async-std-runtime", feature = "async-std-rustls-runtime"))]
+#[cfg(any(
+    feature = "async-std-runtime",
+    feature = "async-std-rustls-runtime-aws-lc-rs",
+    feature = "async-std-rustls-runtime-ring"
+))]
 pub use executor::AsyncStdExecutor;
 pub use executor::Executor;
-#[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+#[cfg(any(
+    feature = "tokio-runtime",
+    feature = "tokio-rustls-runtime-aws-lc-rs",
+    feature = "tokio-rustls-runtime-ring"
+))]
 pub use executor::TokioExecutor;
 pub use message::{
     proto::{self, command_subscribe::SubType, CommandSendReceipt},
@@ -198,7 +226,12 @@ mod retry_op;
 mod service_discovery;
 
 #[cfg(all(
-    any(feature = "tokio-rustls-runtime", feature = "async-std-rustls-runtime"),
+    any(
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring",
+        feature = "async-std-rustls-runtime-aws-lc-rs",
+        feature = "async-std-rustls-runtime-ring"
+    ),
     not(any(feature = "tokio-runtime", feature = "async-std-runtime"))
 ))]
 pub(crate) type Certificate = rustls::pki_types::CertificateDer<'static>;
@@ -216,11 +249,19 @@ mod tests {
     use futures::{future::try_join_all, StreamExt};
     use log::{LevelFilter, Metadata, Record};
     use serde_json::Value;
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     use tokio::time::timeout;
 
     use super::*;
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     use crate::executor::TokioExecutor;
     use crate::{
         client::SerializeMessage,
@@ -284,7 +325,11 @@ mod tests {
     pub static TEST_LOGGER: SimpleLogger = SimpleLogger { tag: "" };
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn round_trip() {
         let _result = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Debug);
@@ -349,7 +394,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn unsized_data() {
         let _result = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Debug);
@@ -435,7 +484,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn redelivery() {
         let _result = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Debug);
@@ -483,7 +536,11 @@ mod tests {
     const EMPTY_VALUES: Vec<String> = vec![];
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn batching() {
         use assert_matches::assert_matches;
 
@@ -613,7 +670,11 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "tokio-rustls-runtime-aws-lc-rs",
+        feature = "tokio-rustls-runtime-ring"
+    ))]
     async fn flush() {
         let _result = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Debug);

--- a/src/message.rs
+++ b/src/message.rs
@@ -220,7 +220,11 @@ impl Message {
 /// tokio and async-std codec for Pulsar messages
 pub struct Codec;
 
-#[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+#[cfg(any(
+    feature = "tokio-runtime",
+    feature = "tokio-rustls-runtime-aws-lc-rs",
+    feature = "tokio-rustls-runtime-ring"
+))]
 impl tokio_util::codec::Encoder<Message> for Codec {
     type Error = ConnectionError;
 
@@ -269,7 +273,11 @@ impl tokio_util::codec::Encoder<Message> for Codec {
     }
 }
 
-#[cfg(any(feature = "tokio-runtime", feature = "tokio-rustls-runtime"))]
+#[cfg(any(
+    feature = "tokio-runtime",
+    feature = "tokio-rustls-runtime-aws-lc-rs",
+    feature = "tokio-rustls-runtime-ring"
+))]
 impl tokio_util::codec::Decoder for Codec {
     type Item = Message;
     type Error = ConnectionError;
@@ -324,7 +332,11 @@ impl tokio_util::codec::Decoder for Codec {
     }
 }
 
-#[cfg(any(feature = "async-std-runtime", feature = "async-std-rustls-runtime"))]
+#[cfg(any(
+    feature = "async-std-runtime",
+    feature = "async-std-rustls-runtime-aws-lc-rs",
+    feature = "async-std-rustls-runtime-ring"
+))]
 impl asynchronous_codec::Encoder for Codec {
     type Item<'a> = Message;
     type Error = ConnectionError;
@@ -374,7 +386,11 @@ impl asynchronous_codec::Encoder for Codec {
     }
 }
 
-#[cfg(any(feature = "async-std-runtime", feature = "async-std-rustls-runtime"))]
+#[cfg(any(
+    feature = "async-std-runtime",
+    feature = "async-std-rustls-runtime-aws-lc-rs",
+    feature = "async-std-rustls-runtime-ring"
+))]
 impl asynchronous_codec::Decoder for Codec {
     type Item = Message;
     type Error = ConnectionError;


### PR DESCRIPTION
Hi!

I had the issue explained in #344 (and it was blocking me because `aws-lc-sys` does not seem to be able to easily cross compile to ARMv6) so I made this change and it seems to fix it.
I'm using my fork successfully in my app.

I'm not sure if this is the right way to fix this though: if I understand correctly, this relies on having either the `aws-lc-rs` or the `ring` Rustls features enabled in the dependency tree(?)

Another way could be to introduce the following features in this crate:

- `tokio-rustls-runtime-ring`
- `tokio-rustls-runtime-aws-lc`
- `async-std-rustls-runtime-ring`
- `async-std-rustls-runtime-aws-lc`

Each would enable the correct features in the Rustls-related dependencies.
The `tokio-rustls-runtime` and `async-std-rustls-runtime` features would be aliases to whatever should be the default.

What do you think?