### PR TITLE
chore: bump version to 6.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsar"
-version = "6.1.0"
+version = "6.4.1"
 edition = "2021"
 authors = [
     "Colin Stearns <cstearns@developers.wyyerd.com>",


### PR DESCRIPTION
Fixes #361 

The next version is 6.4.1 because 6.4.0 introduces some regressions.