### PR TITLE
feat: Updating producer to configure RoutingPolicy - adding partition_key as the default for Round Robin if set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,28 @@ keywords = ["pulsar", "api", "client"]
 [dependencies]
 async-channel = "^2.3.1"
 async-trait = "^0.1.88"
-async-std = { version = "^1.13.1", features = ["attributes", "unstable"], optional = true }
+async-std = { version = "^1.13.1", features = [
+    "attributes",
+    "unstable",
+], optional = true }
 async-native-tls = { version = "^0.5.0", optional = true }
 asynchronous-codec = { version = "^0.7.0", optional = true }
 bytes = "^1.9.0"
-chrono = { version = "^0.4.41", default-features = false, features = ["clock", "std"] }
+chrono = { version = "^0.4.41", default-features = false, features = [
+    "clock",
+    "std",
+] }
 crc = "^3.3.0"
 data-url = { version = "^0.3.1", optional = true }
 flate2 = { version = "^1.1.1", optional = true }
 futures = "^0.3.31"
-futures-rustls = { version = "^0.26.0", default-features = false, features = ["tls12", "logging"], optional = true } # replacement of crate async-rustls (also a fork of tokio-rustls)
+futures-rustls = { version = "^0.26.0", default-features = false, features = [
+    "tls12",
+    "logging",
+], optional = true } # replacement of crate async-rustls (also a fork of tokio-rustls)
 log = "^0.4.27"
 lz4 = { version = "^1.28.0", optional = true }
+murmur3 = "0.5"
 native-tls = { version = "^0.2.12", optional = true }
 nom = { version = "^7.1.3", default-features = false, features = ["alloc"] }
 openidconnect = { version = "^4.0.0", optional = true }
@@ -39,13 +49,23 @@ prost = "^0.13.4"
 prost-derive = "^0.13.4"
 rand = "^0.8.5"
 regex = "^1.11.1"
-rustls = { version = "^0.23.27", default-features = false, features = ["log", "std"] , optional = true }
+rustls = { version = "^0.23.27", default-features = false, features = [
+    "log",
+    "std",
+], optional = true }
 snap = { version = "^1.1.1", optional = true }
 serde = { version = "^1.0.219", features = ["derive"], optional = true }
 serde_json = { version = "^1.0.140", optional = true }
-tokio = { version = "^1.45.0", features = ["rt", "net", "time"], optional = true }
+tokio = { version = "^1.45.0", features = [
+    "rt",
+    "net",
+    "time",
+], optional = true }
 tokio-util = { version = "^0.7.15", features = ["codec"], optional = true }
-tokio-rustls = { version = "0.26.2", default-features = false, features = ["logging", "tls12"], optional = true }
+tokio-rustls = { version = "0.26.2", default-features = false, features = [
+    "logging",
+    "tls12",
+], optional = true }
 tokio-native-tls = { version = "^0.3.1", optional = true }
 tracing = { version = "^0.1.41", optional = true }
 url = "^2.5.4"
@@ -66,10 +86,27 @@ prost-build = "^0.13.4"
 protobuf-src = { version = "^2.1.0", optional = true }
 
 [features]
-async-std-runtime = ["async-std", "asynchronous-codec", "native-tls", "async-native-tls"]
+async-std-runtime = [
+    "async-std",
+    "asynchronous-codec",
+    "native-tls",
+    "async-native-tls",
+]
 async-std-rustls-runtime = ["async-std-rustls-runtime-aws-lc-rs"]
-async-std-rustls-runtime-aws-lc-rs = ["async-std", "asynchronous-codec", "webpki-roots", "rustls/aws-lc-rs", "futures-rustls/aws-lc-rs"]
-async-std-rustls-runtime-ring = ["async-std", "asynchronous-codec", "webpki-roots", "rustls/ring", "futures-rustls/ring"]
+async-std-rustls-runtime-aws-lc-rs = [
+    "async-std",
+    "asynchronous-codec",
+    "webpki-roots",
+    "rustls/aws-lc-rs",
+    "futures-rustls/aws-lc-rs",
+]
+async-std-rustls-runtime-ring = [
+    "async-std",
+    "asynchronous-codec",
+    "webpki-roots",
+    "rustls/ring",
+    "futures-rustls/ring",
+]
 auth-oauth2 = ["openidconnect", "oauth2", "serde", "serde_json", "data-url"]
 compression = ["lz4", "flate2", "zstd", "snap"]
 default = ["compression", "tokio-runtime", "async-std-runtime", "auth-oauth2"]
@@ -77,5 +114,17 @@ protobuf-src = ["dep:protobuf-src"]
 telemetry = ["tracing"]
 tokio-runtime = ["tokio", "tokio-util", "native-tls", "tokio-native-tls"]
 tokio-rustls-runtime = ["tokio-rustls-runtime-aws-lc-rs"]
-tokio-rustls-runtime-aws-lc-rs = ["tokio", "tokio-util", "webpki-roots", "rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
-tokio-rustls-runtime-ring = ["tokio", "tokio-util", "webpki-roots", "rustls/ring", "tokio-rustls/ring"]
+tokio-rustls-runtime-aws-lc-rs = [
+    "tokio",
+    "tokio-util",
+    "webpki-roots",
+    "rustls/aws-lc-rs",
+    "tokio-rustls/aws-lc-rs",
+]
+tokio-rustls-runtime-ring = [
+    "tokio",
+    "tokio-util",
+    "webpki-roots",
+    "rustls/ring",
+    "tokio-rustls/ring",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,28 +18,19 @@ keywords = ["pulsar", "api", "client"]
 [dependencies]
 async-channel = "^2.3.1"
 async-trait = "^0.1.88"
-async-std = { version = "^1.13.1", features = [
-    "attributes",
-    "unstable",
-], optional = true }
+async-std = { version = "^1.13.1", features = ["attributes", "unstable"], optional = true }
 async-native-tls = { version = "^0.5.0", optional = true }
 asynchronous-codec = { version = "^0.7.0", optional = true }
 bytes = "^1.9.0"
-chrono = { version = "^0.4.41", default-features = false, features = [
-    "clock",
-    "std",
-] }
+chrono = { version = "^0.4.41", default-features = false, features = ["clock", "std"] }
 crc = "^3.3.0"
 data-url = { version = "^0.3.1", optional = true }
 flate2 = { version = "^1.1.1", optional = true }
 futures = "^0.3.31"
-futures-rustls = { version = "^0.26.0", default-features = false, features = [
-    "tls12",
-    "logging",
-], optional = true } # replacement of crate async-rustls (also a fork of tokio-rustls)
+futures-rustls = { version = "^0.26.0", default-features = false, features = ["tls12", "logging"], optional = true } # replacement of crate async-rustls (also a fork of tokio-rustls)
 log = "^0.4.27"
 lz4 = { version = "^1.28.0", optional = true }
-murmur3 = "0.5"
+murmur3 = "0.5.2"
 native-tls = { version = "^0.2.12", optional = true }
 nom = { version = "^7.1.3", default-features = false, features = ["alloc"] }
 openidconnect = { version = "^4.0.0", optional = true }
@@ -49,23 +40,13 @@ prost = "^0.13.4"
 prost-derive = "^0.13.4"
 rand = "^0.8.5"
 regex = "^1.11.1"
-rustls = { version = "^0.23.27", default-features = false, features = [
-    "log",
-    "std",
-], optional = true }
+rustls = { version = "^0.23.27", default-features = false, features = ["log", "std"] , optional = true }
 snap = { version = "^1.1.1", optional = true }
 serde = { version = "^1.0.219", features = ["derive"], optional = true }
 serde_json = { version = "^1.0.140", optional = true }
-tokio = { version = "^1.45.0", features = [
-    "rt",
-    "net",
-    "time",
-], optional = true }
+tokio = { version = "^1.45.0", features = ["rt", "net", "time"], optional = true }
 tokio-util = { version = "^0.7.15", features = ["codec"], optional = true }
-tokio-rustls = { version = "0.26.2", default-features = false, features = [
-    "logging",
-    "tls12",
-], optional = true }
+tokio-rustls = { version = "0.26.2", default-features = false, features = ["logging", "tls12"], optional = true }
 tokio-native-tls = { version = "^0.3.1", optional = true }
 tracing = { version = "^0.1.41", optional = true }
 url = "^2.5.4"
@@ -86,27 +67,10 @@ prost-build = "^0.13.4"
 protobuf-src = { version = "^2.1.0", optional = true }
 
 [features]
-async-std-runtime = [
-    "async-std",
-    "asynchronous-codec",
-    "native-tls",
-    "async-native-tls",
-]
+async-std-runtime = ["async-std", "asynchronous-codec", "native-tls", "async-native-tls"]
 async-std-rustls-runtime = ["async-std-rustls-runtime-aws-lc-rs"]
-async-std-rustls-runtime-aws-lc-rs = [
-    "async-std",
-    "asynchronous-codec",
-    "webpki-roots",
-    "rustls/aws-lc-rs",
-    "futures-rustls/aws-lc-rs",
-]
-async-std-rustls-runtime-ring = [
-    "async-std",
-    "asynchronous-codec",
-    "webpki-roots",
-    "rustls/ring",
-    "futures-rustls/ring",
-]
+async-std-rustls-runtime-aws-lc-rs = ["async-std", "asynchronous-codec", "webpki-roots", "rustls/aws-lc-rs", "futures-rustls/aws-lc-rs"]
+async-std-rustls-runtime-ring = ["async-std", "asynchronous-codec", "webpki-roots", "rustls/ring", "futures-rustls/ring"]
 auth-oauth2 = ["openidconnect", "oauth2", "serde", "serde_json", "data-url"]
 compression = ["lz4", "flate2", "zstd", "snap"]
 default = ["compression", "tokio-runtime", "async-std-runtime", "auth-oauth2"]
@@ -114,17 +78,5 @@ protobuf-src = ["dep:protobuf-src"]
 telemetry = ["tracing"]
 tokio-runtime = ["tokio", "tokio-util", "native-tls", "tokio-native-tls"]
 tokio-rustls-runtime = ["tokio-rustls-runtime-aws-lc-rs"]
-tokio-rustls-runtime-aws-lc-rs = [
-    "tokio",
-    "tokio-util",
-    "webpki-roots",
-    "rustls/aws-lc-rs",
-    "tokio-rustls/aws-lc-rs",
-]
-tokio-rustls-runtime-ring = [
-    "tokio",
-    "tokio-util",
-    "webpki-roots",
-    "rustls/ring",
-    "tokio-rustls/ring",
-]
+tokio-rustls-runtime-aws-lc-rs = ["tokio", "tokio-util", "webpki-roots", "rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
+tokio-rustls-runtime-ring = ["tokio", "tokio-util", "webpki-roots", "rustls/ring", "tokio-rustls/ring"]

--- a/examples/producer.rs
+++ b/examples/producer.rs
@@ -17,7 +17,6 @@ impl SerializeMessage for TestData {
     fn serialize_message(input: Self) -> Result<producer::Message, PulsarError> {
         let payload = serde_json::to_vec(&input).map_err(|e| PulsarError::Custom(e.to_string()))?;
         Ok(producer::Message {
-            partition_key: Some(input.data.clone()),
             payload,
             ..Default::default()
         })
@@ -33,7 +32,7 @@ async fn main() -> Result<(), pulsar::Error> {
         .unwrap_or_else(|| "pulsar://127.0.0.1:6650".to_string());
     let topic = env::var("PULSAR_TOPIC")
         .ok()
-        .unwrap_or_else(|| "persistent://public/default/test".to_string());
+        .unwrap_or_else(|| "non-persistent://public/default/test".to_string());
 
     let mut builder = Pulsar::builder(addr, TokioExecutor);
 
@@ -73,10 +72,9 @@ async fn main() -> Result<(), pulsar::Error> {
 
     let mut counter = 0usize;
     loop {
-        let index = counter % 3;
         producer
             .send_non_blocking(TestData {
-                data: "data".to_string() + index.to_string().as_str(),
+                data: "data".to_string(),
             })
             .await?
             .await

--- a/examples/producer.rs
+++ b/examples/producer.rs
@@ -17,6 +17,7 @@ impl SerializeMessage for TestData {
     fn serialize_message(input: Self) -> Result<producer::Message, PulsarError> {
         let payload = serde_json::to_vec(&input).map_err(|e| PulsarError::Custom(e.to_string()))?;
         Ok(producer::Message {
+            partition_key: Some(input.data.clone()),
             payload,
             ..Default::default()
         })
@@ -32,7 +33,7 @@ async fn main() -> Result<(), pulsar::Error> {
         .unwrap_or_else(|| "pulsar://127.0.0.1:6650".to_string());
     let topic = env::var("PULSAR_TOPIC")
         .ok()
-        .unwrap_or_else(|| "non-persistent://public/default/test".to_string());
+        .unwrap_or_else(|| "persistent://public/default/test".to_string());
 
     let mut builder = Pulsar::builder(addr, TokioExecutor);
 
@@ -72,9 +73,10 @@ async fn main() -> Result<(), pulsar::Error> {
 
     let mut counter = 0usize;
     loop {
+        let index = counter % 3;
         producer
             .send_non_blocking(TestData {
-                data: "data".to_string(),
+                data: "data".to_string() + index.to_string().as_str(),
             })
             .await?
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@ pub mod message;
 pub mod producer;
 pub mod reader;
 mod retry_op;
+pub mod routing_policy;
 mod service_discovery;
 
 #[cfg(all(

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1623,7 +1623,7 @@ mod tests {
         );
         for _ in 1..100 {
             let next_producer = partitioned_producer.choose_partition(&message);
-            assert!(next_producer.id as usize == chosen_index);
+            assert!(next_producer.name == chosen_index.to_string());
         }
     }
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1433,7 +1433,6 @@ impl<T: SerializeMessage + Sized, Exe: Executor> MessageBuilder<'_, T, Exe> {
 mod tests {
     use futures::executor::block_on;
     use log::LevelFilter;
-    use serde_json::Value;
 
     use super::*;
     use crate::{routing_policy::CustomRoutingPolicy, tests::TEST_LOGGER, TokioExecutor};

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1774,20 +1774,5 @@ mod tests {
             .await
             .unwrap();
         assert!(response.status().is_success());
-
-        let get_partitioned_topic_metadata = format!(
-            "http://127.0.0.1:8080/admin/v2/persistent/{tenant}/{namespace}/{topic_name}/internal-info"
-        );
-        let client = reqwest::Client::new();
-        let response = client
-            .get(get_partitioned_topic_metadata)
-            .send()
-            .await
-            .unwrap();
-        println!("{:?}", response);
-        assert!(response.status().is_success());
-
-        let json_value: Value = response.json().await.unwrap();
-        println!("{:?}", json_value["partitions"]);
     }
 }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1569,16 +1569,15 @@ mod tests {
         let _result = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Debug);
         let pulsar: Pulsar<_> = Pulsar::builder("pulsar://127.0.0.1:6650", TokioExecutor)
-            .with_outbound_channel_size(3)
             .build()
             .await
             .unwrap();
-        let topic = "topic-test_round_robin_routing_policy";
+        let topic = format!("topic_{}", rand::random::<u16>());
         let options = ProducerOptions {
             routing_policy: Some(RoutingPolicy::RoundRobin),
             ..Default::default()
         };
-        let addr = pulsar.lookup_topic(topic).await.unwrap();
+        let addr = pulsar.lookup_topic(topic.clone()).await.unwrap();
         let partition_count = 3;
 
         let mut producers = Vec::new();
@@ -1586,8 +1585,8 @@ mod tests {
             let producer = TopicProducer::new(
                 pulsar.clone(),
                 addr.clone(),
-                format!("{}-{}", topic, i),
-                None,
+                format!("{}-{}", topic.clone(), i),
+                Some(i.to_string()),
                 options.clone(),
             )
             .await
@@ -1608,7 +1607,7 @@ mod tests {
 
         for i in 1..100 {
             let next_producer = partitioned_producer.choose_partition(&message);
-            assert!(next_producer.id == i % partition_count);
+            assert!(next_producer.name == (i % partition_count).to_string());
         }
 
         let key = "test";
@@ -1633,16 +1632,15 @@ mod tests {
         let _result = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Debug);
         let pulsar: Pulsar<_> = Pulsar::builder("pulsar://127.0.0.1:6650", TokioExecutor)
-            .with_outbound_channel_size(3)
             .build()
             .await
             .unwrap();
-        let topic = "topic-test_single_routing_policy";
+        let topic = format!("topic_{}", rand::random::<u16>());
         let options = ProducerOptions {
             routing_policy: Some(RoutingPolicy::Single(2)),
             ..Default::default()
         };
-        let addr = pulsar.lookup_topic(topic).await.unwrap();
+        let addr = pulsar.lookup_topic(topic.clone()).await.unwrap();
         let partition_count = 3;
 
         let mut producers = Vec::new();
@@ -1650,8 +1648,8 @@ mod tests {
             let producer = TopicProducer::new(
                 pulsar.clone(),
                 addr.clone(),
-                format!("{}-{}", topic, i),
-                None,
+                format!("{}-{}", topic.clone(), i),
+                Some(i.to_string()),
                 options.clone(),
             )
             .await
@@ -1674,7 +1672,7 @@ mod tests {
 
         for _ in 1..100 {
             let next_producer = partitioned_producer.choose_partition(&message);
-            assert!(next_producer.id == 2);
+            assert!(next_producer.name == 2.to_string());
         }
     }
 
@@ -1691,16 +1689,15 @@ mod tests {
         let _result = log::set_logger(&TEST_LOGGER);
         log::set_max_level(LevelFilter::Debug);
         let pulsar: Pulsar<_> = Pulsar::builder("pulsar://127.0.0.1:6650", TokioExecutor)
-            .with_outbound_channel_size(3)
             .build()
             .await
             .unwrap();
-        let topic = "topic-test_custom_routing_policy";
+        let topic = format!("topic_{}", rand::random::<u16>());
         let options = ProducerOptions {
             routing_policy: Some(RoutingPolicy::Custom(Arc::new(TestCustomRoutingPolicy {}))),
             ..Default::default()
         };
-        let addr = pulsar.lookup_topic(topic).await.unwrap();
+        let addr = pulsar.lookup_topic(topic.clone()).await.unwrap();
         let partition_count = 3;
 
         let mut producers = Vec::new();
@@ -1708,8 +1705,8 @@ mod tests {
             let producer = TopicProducer::new(
                 pulsar.clone(),
                 addr.clone(),
-                format!("{}-{}", topic, i),
-                None,
+                format!("{}-{}", topic.clone(), i),
+                Some(i.to_string()),
                 options.clone(),
             )
             .await
@@ -1732,7 +1729,7 @@ mod tests {
 
         for _ in 1..100 {
             let next_producer = partitioned_producer.choose_partition(&message);
-            assert!(next_producer.id == 1);
+            assert!(next_producer.name == 1.to_string());
         }
     }
 }

--- a/src/routing_policy.rs
+++ b/src/routing_policy.rs
@@ -24,3 +24,56 @@ impl RoutingPolicy {
 pub trait CustomRoutingPolicy: Send + Sync {
     fn route(&self, message: &Message, num_producers: usize) -> usize;
 }
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use crate::routing_policy::RoutingPolicy;
+
+    #[test]
+    fn test_compute_partition_index_consistency() {
+        let partition_count = 4;
+        let key = Uuid::new_v4().to_string();
+
+        let partition_index = RoutingPolicy::compute_partition_index_for_key(&key, partition_count);
+        assert!(partition_index < partition_count);
+
+        for _ in 0..10 {
+            let other_partition_index =
+                RoutingPolicy::compute_partition_index_for_key(&key, partition_count);
+            assert!(other_partition_index < partition_count);
+            assert_eq!(
+                partition_index, other_partition_index,
+                "partition index should be deterministic for the same key"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_partition_index_distribution() {
+        let partition_count = 4;
+        let mut partition_counts = vec![0; partition_count];
+
+        let total = 1000;
+        for _ in 0..total {
+            let partition_index = RoutingPolicy::compute_partition_index_for_key(
+                &Uuid::new_v4().to_string(),
+                partition_count,
+            );
+            partition_counts[partition_index] += 1;
+        }
+
+        for count in partition_counts {
+            let ratio = count as f64 / total as f64;
+            let expected_ratio = 1.0 / partition_count as f64;
+
+            assert!(
+                ratio > (expected_ratio - 0.1) && ratio < (expected_ratio + 0.1),
+                "distribution ratio {} is not near expected ratio {}",
+                ratio,
+                expected_ratio
+            );
+        }
+    }
+}

--- a/src/routing_policy.rs
+++ b/src/routing_policy.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+
+use murmur3::murmur3_32;
+
+use crate::producer::Message;
+
+#[derive(Clone, Default)]
+pub enum RoutingPolicy {
+    #[default]
+    RoundRobin,
+    Single(usize),
+    Custom(Arc<dyn CustomRoutingPolicy>),
+}
+
+impl RoutingPolicy {
+    pub fn compute_partition_index_for_key(key: &str, partition_count: usize) -> usize {
+        // Use murmur3 hash for deterministic results across restarts
+        // Using a fixed seed (0) ensures consistent hashing
+        let hash = murmur3_32(&mut key.as_bytes(), 0).unwrap_or(0);
+        (hash % partition_count as u32) as usize
+    }
+}
+
+pub trait CustomRoutingPolicy: Send + Sync {
+    fn route(&self, message: &Message, num_producers: usize) -> usize;
+}

--- a/src/routing_policy.rs
+++ b/src/routing_policy.rs
@@ -8,7 +8,7 @@ use crate::producer::Message;
 pub enum RoutingPolicy {
     #[default]
     RoundRobin,
-    Single(usize),
+    Single,
     Custom(Arc<dyn CustomRoutingPolicy>),
 }
 


### PR DESCRIPTION
Should address: https://github.com/streamnative/pulsar-rs/issues/322

https://pulsar.apache.org/docs/next/client-libraries-producers/#choose-partitions-when-using-a-key

Copying the behavior in the Java Client, where the producer takes in a configuration for a RoutingPolicy (RoundRobin, Single or Custom) for publishing to a partitioned topic. 

Non breaking behavior since if you don't specify a routing policy, it will automtically be Round Robin. Similarly to the Java Client, if you explicitly have a partition_key set in your message, it will deterministically hash the key and route to a partition that way