### PR TITLE
Added crc32 integrity check in message.rs. Fixed little variable name typo

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -325,9 +325,10 @@ impl tokio_util::codec::Decoder for Codec {
                                 data: buf.to_vec(),
                             })
                         } else {
-                            return Err(ConnectionError::Decoding(format!(
+                            return Err(ConnectionError::Decoding(
                                 "Checksum mismatch, invalid payload"
-                            )));
+                            .to_string()));
+                            
                         }
                     } else {
                         None
@@ -452,9 +453,9 @@ impl asynchronous_codec::Decoder for Codec {
                                 data: buf.to_vec(),
                             })
                         } else {
-                            return Err(ConnectionError::Decoding(format!(
+                            return Err(ConnectionError::Decoding(
                                 "Checksum mismatch, invalid payload"
-                            )));
+                            .to_string()));
                         }
                     } else {
                         None

--- a/src/message.rs
+++ b/src/message.rs
@@ -326,9 +326,8 @@ impl tokio_util::codec::Decoder for Codec {
                             })
                         } else {
                             return Err(ConnectionError::Decoding(
-                                "Checksum mismatch, invalid payload"
-                            .to_string()));
-                            
+                                "Checksum mismatch, invalid payload".to_string(),
+                            ));
                         }
                     } else {
                         None
@@ -454,8 +453,8 @@ impl asynchronous_codec::Decoder for Codec {
                             })
                         } else {
                             return Err(ConnectionError::Decoding(
-                                "Checksum mismatch, invalid payload"
-                            .to_string()));
+                                "Checksum mismatch, invalid payload".to_string(),
+                            ));
                         }
                     } else {
                         None


### PR DESCRIPTION
Hi everyone, this PR adds a CRC32 integrity check in the decode functions in message.rs  (it was previously annotated as TODO).

### Tests
- cargo test: all checks passed: 
   - 24/24 passed 
   - 0 ignored 
   - 0 failed
- Verified end-to-end with the producer and consumer example.