### PR TITLE
fix: Stop disconnecting consumers from MultiTopicConsumer on connection errors if not using regex

### DIFF
--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -383,7 +383,11 @@ impl<T: 'static + DeserializeMessage, Exe: Executor> Stream for MultiTopicConsum
                             "Unexpected error consuming from pulsar topic {}: {}",
                             &topic, e
                         );
-                        topics_to_remove.push(topic.clone());
+                        // Only remove topic from MultiTopicConsumer on error if they
+                        // can be re-added later by regex
+                        if self.topic_regex.is_some() {
+                            topics_to_remove.push(topic.clone());
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
- https://github.com/streamnative/pulsar-rs/issues/375

A MultiTopicConsumer contains many child Consumers, one for every partitioned topic, and when you poll the MultiTopicConsumer it polls all child consumers until a new message is ready.

This works great in non-error conditions, but in some rare cases, such as when one or more pulsar brokers are restart in sequence, the child consumer can return `Poll::Ready(Some(Err(e)))`

The previous behavior was to assume the child consumer was dead and to remove it from the MultiTopicConsumer. This is reasonable if you are using the regex refresh feature, where topics will be discovered at runtime dynamically. However, this is completely the wrong behavior when you have a fixed topic list at startup. Silently dropping a child topic means your MultiTopicConsumer will never listen to that topic ever again.

There is no test included, as an automated test that shut down the entire broker during a test would not behave well locally/CI. It was tested with the example included in the issue - https://github.com/chamons/pulsar-load-shed-repro