### PR TITLE
perf: remove unnecessary clones from multitopic producer

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1225,11 +1225,15 @@ impl<Exe: Executor> Connection<Exe> {
                 Some(error.message),
             )),
             Some(Ok(msg)) => {
-                let cmd = msg.command.clone();
-                trace!("received connection response: {:?}", msg);
-                msg.command.connected.ok_or_else(|| {
-                    ConnectionError::Unexpected(format!("Unexpected message from pulsar: {cmd:?}"))
-                })
+                trace!("received connection response: {:?}", &msg);
+                let Some(c) = msg.command.connected else {
+                    return Err(ConnectionError::Unexpected(format!(
+                        "Unexpected message from pulsar: {:?}",
+                        &msg.command
+                    )));
+                };
+
+                Ok(c)
             }
             Some(Err(e)) => Err(e),
             None => Err(ConnectionError::Disconnected),


### PR DESCRIPTION
Small improvement to `send_non_blocking()` on multi-topic producers to use the entry API. Removes the need to clone the topic name and get the producer after inserting it. Additional removal of an unnecessary clone on the `connect()` method