### PR TITLE
cleanup(compression): replace Default and Clone custom traits with a direct implementation from the official library

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -17,36 +17,10 @@ pub enum Compression {
 
 /// Options of the [lz4](https://lz4.github.io/lz4/) algorithm
 #[cfg(feature = "lz4")]
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub struct CompressionLz4 {
     /// compression mode of lz4 to be used
     pub mode: lz4::block::CompressionMode,
-}
-
-// FIXME: can be omitted if https://github.com/10XGenomics/lz4-rs/pull/31 released
-#[cfg(feature = "lz4")]
-impl Default for CompressionLz4 {
-    fn default() -> Self {
-        CompressionLz4 {
-            mode: lz4::block::CompressionMode::DEFAULT,
-        }
-    }
-}
-
-// FIXME: can be omitted if https://github.com/10XGenomics/lz4-rs/pull/30 released
-#[cfg(feature = "lz4")]
-impl Clone for CompressionLz4 {
-    fn clone(&self) -> Self {
-        use lz4::block::CompressionMode;
-
-        CompressionLz4 {
-            mode: match self.mode {
-                CompressionMode::HIGHCOMPRESSION(i) => CompressionMode::HIGHCOMPRESSION(i),
-                CompressionMode::FAST(i) => CompressionMode::FAST(i),
-                CompressionMode::DEFAULT => CompressionMode::DEFAULT,
-            },
-        }
-    }
 }
 
 /// Options of the [zlib](https://www.zlib.net/) algorithm


### PR DESCRIPTION
Hi everyone, this PR replaces the old Default and Clone custom traits with a direct implementation of Default and Clone traits from the 10xGenomics lz4 library (was annotated as FIXME suggestion)