### PR TITLE
fix: Correctly handle consumer errors and removal due to pulsar cluster restarts by unconditionally update_topics in MultiTopicConsumer

### DIFF
--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -118,7 +118,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
         self
     }
 
-    /// Interval for refreshing the topics when using a topic regex. Unused otherwise.
+    /// Interval for refreshing the topics when using a topic regex or when errors occur with a MultiTopicConsumer
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_topic_refresh(mut self, refresh_interval: Duration) -> Self {
         self.topic_refresh = Some(refresh_interval);

--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -194,7 +194,7 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
                     }),
             )
             .await?;
-            trace!("created {} consumers", consumers.len());
+            info!("created {} consumers", consumers.len());
             Ok(consumers)
         }));
     }
@@ -352,11 +352,9 @@ impl<T: 'static + DeserializeMessage, Exe: Executor> Stream for MultiTopicConsum
             }
         }
 
-        if self.topic_regex.is_some() {
-            if let Poll::Ready(Some(_)) = self.refresh.as_mut().poll_next(cx) {
-                self.update_topics();
-                return self.poll_next(cx);
-            }
+        if let Poll::Ready(Some(_)) = self.refresh.as_mut().poll_next(cx) {
+            self.update_topics();
+            return self.poll_next(cx);
         }
 
         let mut topics_to_remove = Vec::new();
@@ -383,11 +381,7 @@ impl<T: 'static + DeserializeMessage, Exe: Executor> Stream for MultiTopicConsum
                             "Unexpected error consuming from pulsar topic {}: {}",
                             &topic, e
                         );
-                        // Only remove topic from MultiTopicConsumer on error if they
-                        // can be re-added later by regex
-                        if self.topic_regex.is_some() {
-                            topics_to_remove.push(topic.clone());
-                        }
+                        topics_to_remove.push(topic.clone());
                     }
                 }
             } else {


### PR DESCRIPTION
While testing https://github.com/streamnative/pulsar-rs/pull/379 it was found in that cases when the entire pulsar broker was restarted, we'd hit a similar case:

- Instead of hitting Some(Err(e) at https://github.com/streamnative/pulsar-rs/blob/a14e8a15144a48d7d97b20c6a7fc637cbf5d780b/src/consumer/multi.rs#L381-L391
- We hit None at https://github.com/streamnative/pulsar-rs/blob/a14e8a15144a48d7d97b20c6a7fc637cbf5d780b/src/consumer/multi.rs#L377-L379

This means we still rip out the topic out of the MultiTopicConsumer forever.

I originally was going to apply a similar fix to #379, but review of the code made me realize that there was code in:

https://github.com/streamnative/pulsar-rs/blob/a14e8a15144a48d7d97b20c6a7fc637cbf5d780b/src/consumer/multi.rs#L145C12-L145C25

That actually handle keeping the initial topics around by recreating them.

It however, wasn't being called because the call was guarded by a topic_regex existence check.

I believe it is necessary for this code to be unconditionally called, because errors in consumers can drop them from a MultiTopicConsumer and we need to recreate.

Local testing confirmed that it works, with 5 full restarts of our staging pulsar cluster while under loading not hanging up once.