### PR TITLE
fix(consumer): `update_topics` should only log if topics are recreated

### DIFF
--- a/src/consumer/multi.rs
+++ b/src/consumer/multi.rs
@@ -194,7 +194,14 @@ impl<T: DeserializeMessage, Exe: Executor> MultiTopicConsumer<T, Exe> {
                     }),
             )
             .await?;
-            info!("created {} consumers", consumers.len());
+            if !consumers.is_empty() {
+                let topics: Vec<String> = consumers.iter().map(|c| c.topic()).collect();
+                info!(
+                    "recreated {} consumers for topics: {:?}",
+                    consumers.len(),
+                    topics
+                );
+            }
             Ok(consumers)
         }));
     }


### PR DESCRIPTION
When using `multi` topics (or regex), when disconnected topic partitions are found, it will recreate their consumers. The logging statement for this was quite noisy in a production environment. Change the code to only log if it finds missing partitions, and also log the topic names so that this functionality can be traced in logs.

Fixes: #389