### PR TITLE
fix: make oauth2 connectivity errors retriable

### DIFF
--- a/src/authentication/oauth2.rs
+++ b/src/authentication/oauth2.rs
@@ -333,7 +333,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn auth_data_returns_retriable_on_request_error() {
+    async fn auth_data_returns_retriable_error() {
         let params = OAuth2Params {
             issuer_url: "http://issuer.example".to_string(),
             credentials_url: "data:application/json;base64,eyJjbGllbnRfaWQiOiJpZCIsImNsaWVudF9zZWNyZXQiOiJzZWNyZXQifQ==".to_string(),

--- a/src/authentication/oauth2.rs
+++ b/src/authentication/oauth2.rs
@@ -295,10 +295,10 @@ impl OAuth2Authentication {
                 "token endpoint request failed for issuer [{}] (audience={:?}, scope={:?}): {e:?}",
                 self.params.issuer_url, self.params.audience, self.params.scope
             );
-            if let RequestTokenError::Request(_) = e {
-                AuthenticationError::Retriable(error_message)
-            } else {
+            if let RequestTokenError::ServerResponse(_) = e {
                 AuthenticationError::Custom(error_message)
+            } else {
+                AuthenticationError::Retriable(error_message)
             }
         })?;
         debug!("Got a new oauth2 token for [{}]", self.params);

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,6 +120,7 @@ impl ConnectionError {
             ConnectionError::Io(e) => {
                 e.kind() == io::ErrorKind::ConnectionRefused || e.kind() == io::ErrorKind::TimedOut
             }
+            ConnectionError::Authentication(AuthenticationError::Retriable(_)) => true,
             _ => false,
         }
     }
@@ -458,6 +459,7 @@ impl std::error::Error for ServiceDiscoveryError {
 #[derive(Clone, Debug)]
 pub enum AuthenticationError {
     Custom(String),
+    Retriable(String),
 }
 
 impl fmt::Display for AuthenticationError {
@@ -465,6 +467,7 @@ impl fmt::Display for AuthenticationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AuthenticationError::Custom(m) => write!(f, "{m}"),
+            AuthenticationError::Retriable(m) => write!(f, "{m} (retriable)"),
         }
     }
 }


### PR DESCRIPTION
See https://github.com/ramosbugs/oauth2-rs/blob/72ce74401c26eb4dc85dcbfde587bbcfc149e3ae/oauth2/src/error.rs#L120, only `ServerResponse` should be fatal error because it's the response returned by the auth server that indicates the auth info does not have enough permission.