### PR TITLE
fix: Preserve message metadata when sending to DLQ

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1543,6 +1543,7 @@ pub(crate) mod messages {
                     publish_time: Utc::now().timestamp_millis() as u64,
                     replicated_from: None,
                     partition_key: message.partition_key,
+                    ordering_key: message.ordering_key,
                     replicate_to: message.replicate_to,
                     compression: message.compression,
                     uncompressed_size: message.uncompressed_size,

--- a/src/consumer/batched_message_iterator.rs
+++ b/src/consumer/batched_message_iterator.rs
@@ -51,6 +51,7 @@ impl Iterator for BatchedMessageIterator {
             let metadata = Metadata {
                 properties: batched_message.metadata.properties,
                 partition_key: batched_message.metadata.partition_key,
+                ordering_key: batched_message.metadata.ordering_key,
                 event_time: batched_message.metadata.event_time,
                 ..self.metadata.clone()
             };

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -462,6 +462,14 @@ mod tests {
         msg: u32,
     }
 
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct TestMessageMetadata {
+        properties: HashMap<String, String>,
+        partition_key: Option<String>,
+        ordering_key: Option<Vec<u8>>,
+        event_time: Option<u64>,
+    }
+
     impl SerializeMessage for &TestData {
         fn serialize_message(input: Self) -> Result<producer::Message, Error> {
             let payload = serde_json::to_vec(&input).map_err(|e| Error::Custom(e.to_string()))?;
@@ -846,19 +854,21 @@ mod tests {
             topic: topic.clone(),
             msg: test_msg,
         };
-        let message_properties = HashMap::from([
-            ("k_1".to_string(), "v_1".to_string()),
-            ("k_2".to_string(), "v_2".to_string()),
-        ]);
-        let message_partition_key = Some("partition_key".to_string());
-        let message_ordering_key = Some(b"ordering_key".to_vec());
-        let message_event_time = Some(rand::random());
+        let message_metadata = TestMessageMetadata {
+            properties: HashMap::from([
+                ("k_1".to_string(), "v_1".to_string()),
+                ("k_2".to_string(), "v_2".to_string()),
+            ]),
+            partition_key: Some("partition_key".to_string()),
+            ordering_key: Some(b"ordering_key".to_vec()),
+            event_time: Some(rand::random()),
+        };
 
         let mut message = <&TestData>::serialize_message(&message_data).unwrap();
-        message.properties = message_properties.clone();
-        message.partition_key = message_partition_key.clone();
-        message.ordering_key = message_ordering_key.clone();
-        message.event_time = message_event_time;
+        message.properties = message_metadata.properties.clone();
+        message.partition_key = message_metadata.partition_key.clone();
+        message.ordering_key = message_metadata.ordering_key.clone();
+        message.event_time = message_metadata.event_time;
 
         let dead_letter_topic = format!("{topic}_dlq");
 
@@ -922,7 +932,7 @@ mod tests {
             "we probably received a message from a previous run of the test"
         );
         assert_eq!(
-            message_properties,
+            message_metadata.properties,
             dlq_msg
                 .metadata()
                 .properties
@@ -932,17 +942,17 @@ mod tests {
             "message properties should be preserved when the message is sent to the DLQ"
         );
         assert_eq!(
-            message_partition_key,
+            message_metadata.partition_key,
             dlq_msg.metadata().partition_key,
             "message partition key should be preserved when the message is sent to the DLQ"
         );
         assert_eq!(
-            message_ordering_key,
+            message_metadata.ordering_key,
             dlq_msg.metadata().ordering_key,
             "message ordering key should be preserved when the message is sent to the DLQ"
         );
         assert_eq!(
-            message_event_time,
+            message_metadata.event_time,
             dlq_msg.metadata().event_time,
             "message event time should be preserved when the message is sent to the DLQ"
         );
@@ -1011,28 +1021,61 @@ mod tests {
             .await
             .unwrap();
 
-        let messages = vec![
-            TestData {
-                topic: topic.clone(),
-                msg: rand::random(),
-            },
-            TestData {
-                topic: topic.clone(),
-                msg: rand::random(),
-            },
+        let message_datas = vec![
+            (
+                TestData {
+                    topic: topic.clone(),
+                    msg: rand::random(),
+                },
+                TestMessageMetadata {
+                    properties: HashMap::from([
+                        ("k_1_1".to_string(), "v_1_1".to_string()),
+                        ("k_2_1".to_string(), "v_2_1".to_string()),
+                    ]),
+                    partition_key: Some("partition_key_1".to_string()),
+                    ordering_key: Some(b"ordering_key_1".to_vec()),
+                    event_time: Some(rand::random()),
+                },
+            ),
+            (
+                TestData {
+                    topic: topic.clone(),
+                    msg: rand::random(),
+                },
+                TestMessageMetadata {
+                    properties: HashMap::from([
+                        ("k_1_2".to_string(), "v_1_2".to_string()),
+                        ("k_2_2".to_string(), "v_2_2".to_string()),
+                    ]),
+                    partition_key: Some("partition_key_2".to_string()),
+                    ordering_key: Some(b"ordering_key_2".to_vec()),
+                    event_time: Some(rand::random()),
+                },
+            ),
         ];
-        let receipts = producer.send_all(&messages).await.unwrap();
+        let messages = message_datas
+            .iter()
+            .map(|(data, metadata)| {
+                let mut message = <&TestData>::serialize_message(data).unwrap();
+                message.properties = metadata.properties.clone();
+                message.partition_key = metadata.partition_key.clone();
+                message.ordering_key = metadata.ordering_key.clone();
+                message.event_time = metadata.event_time;
+                message
+            })
+            .collect::<Vec<_>>();
+        let receipts = producer.send_all(messages).await.unwrap();
         producer.send_batch().await.unwrap();
         try_join_all(receipts).await.unwrap();
         println!("producer sends done");
 
-        for message in messages {
+        for (message_data, message_metadata) in message_datas {
             let msg = recv_within(&mut consumer, DEFAULT_RECV_TIMEOUT)
                 .await
                 .unwrap();
             println!("got message: {:?}", msg.payload);
             assert_eq!(
-                message,
+                message_data,
                 msg.deserialize().unwrap(),
                 "we probably received a message from a previous run of the test"
             );
@@ -1044,9 +1087,34 @@ mod tests {
                 .unwrap();
             println!("got message: {:?}", dlq_msg.payload);
             assert_eq!(
-                message,
+                message_data,
                 dlq_msg.deserialize().unwrap(),
                 "we probably received a message from a previous run of the test"
+            );
+            assert_eq!(
+                message_metadata.properties,
+                dlq_msg
+                    .metadata()
+                    .properties
+                    .iter()
+                    .map(|p| (p.key.clone(), p.value.clone()))
+                    .collect::<HashMap<_, _>>(),
+                "message properties should be preserved when the message is sent to the DLQ"
+            );
+            assert_eq!(
+                message_metadata.partition_key,
+                dlq_msg.metadata().partition_key,
+                "message partition key should be preserved when the message is sent to the DLQ"
+            );
+            assert_eq!(
+                message_metadata.ordering_key,
+                dlq_msg.metadata().ordering_key,
+                "message ordering key should be preserved when the message is sent to the DLQ"
+            );
+            assert_eq!(
+                message_metadata.event_time,
+                dlq_msg.metadata().event_time,
+                "message event time should be preserved when the message is sent to the DLQ"
             );
             dlq_consumer.ack(&dlq_msg).await.unwrap();
         }

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -931,8 +931,22 @@ mod tests {
             dlq_msg.deserialize().unwrap(),
             "we probably received a message from a previous run of the test"
         );
+        let mut expected_properties = message_metadata.properties;
+        expected_properties
+            .entry("REAL_TOPIC".to_string())
+            .or_insert_with(|| topic.clone());
+        expected_properties
+            .entry("ORIGIN_MESSAGE_ID".to_string())
+            .or_insert_with(|| {
+                format!(
+                    "{}:{}:{}",
+                    msg.message_id().ledger_id,
+                    msg.message_id().entry_id,
+                    msg.message_id().partition.unwrap_or(-1)
+                )
+            });
         assert_eq!(
-            message_metadata.properties,
+            expected_properties,
             dlq_msg
                 .metadata()
                 .properties
@@ -1091,8 +1105,23 @@ mod tests {
                 dlq_msg.deserialize().unwrap(),
                 "we probably received a message from a previous run of the test"
             );
+            let mut expected_properties = message_metadata.properties;
+            expected_properties
+                .entry("REAL_TOPIC".to_string())
+                .or_insert_with(|| topic.clone());
+            expected_properties
+                .entry("ORIGIN_MESSAGE_ID".to_string())
+                .or_insert_with(|| {
+                    format!(
+                        "{}:{}:{}:{}",
+                        msg.message_id().ledger_id,
+                        msg.message_id().entry_id,
+                        msg.message_id().partition.unwrap_or(-1),
+                        msg.message_id().batch_index.unwrap_or(-1)
+                    )
+                });
             assert_eq!(
-                message_metadata.properties,
+                expected_properties,
                 dlq_msg
                     .metadata()
                     .properties


### PR DESCRIPTION
Mimic behavior of java client from https://github.com/apache/pulsar/blob/4cbe124841fdc92ab671b1e438a86522a70bd622/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L2345

Also includes #294 since the modifications to the tests require ordering key to be properly forwarded in the Message.

Because of the test changes it should properly address the request in https://github.com/streamnative/pulsar-rs/pull/294#pullrequestreview-1620269534 to have a test that guards against this.