### PR TITLE
Fix producer not reconnecting after receipt timeout

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -905,39 +905,52 @@ where
     Exe: Executor,
 {
     loop {
-        match connection
-            .sender()
-            .send(
-                producer_id,
-                producer_name.clone(),
-                sequence_id.get(),
-                message.clone(),
-                options.block_queue_if_full,
-            )
-            .await
-        {
-            Ok(fut) => {
-                let fut = async move {
-                    let res = fut.await;
-                    res.map_err(|e| {
-                        error!("wait send receipt got error: {:?}", e);
-                        Error::Producer(ProducerError::Connection(e))
-                    })
-                };
-                return Ok(fut);
-            }
-            Err(ConnectionError::Disconnected) => {}
-            Err(ConnectionError::Io(e)) => {
-                if e.kind() != std::io::ErrorKind::TimedOut {
-                    error!("send_message got io error: {:?}", e);
-                    return Err(ProducerError::Connection(ConnectionError::Io(e)).into());
+        // If a previous send timed out waiting for a receipt, the connection
+        // is poisoned (error flag set) but the underlying TCP channel may
+        // still be open.  Detect this early and fall through to reconnection
+        // instead of sending into a black hole that will time out again.
+        if !connection.is_valid() {
+            warn!(
+                "send_message: connection {} is no longer valid, reconnecting producer for topic: {}",
+                connection.id(),
+                topic
+            );
+            // fall through to reconnection below
+        } else {
+            match connection
+                .sender()
+                .send(
+                    producer_id,
+                    producer_name.clone(),
+                    sequence_id.get(),
+                    message.clone(),
+                    options.block_queue_if_full,
+                )
+                .await
+            {
+                Ok(fut) => {
+                    let fut = async move {
+                        let res = fut.await;
+                        res.map_err(|e| {
+                            error!("wait send receipt got error: {:?}", e);
+                            Error::Producer(ProducerError::Connection(e))
+                        })
+                    };
+                    return Ok(fut);
+                }
+                Err(ConnectionError::Disconnected) => {}
+                Err(ConnectionError::Io(e)) => {
+                    if e.kind() != std::io::ErrorKind::TimedOut {
+                        error!("send_message got io error: {:?}", e);
+                        return Err(ProducerError::Connection(ConnectionError::Io(e)).into());
+                    }
+                }
+                Err(e) => {
+                    error!("send_message got error: {:?}", e);
+                    return Err(ProducerError::Connection(e).into());
                 }
             }
-            Err(e) => {
-                error!("send_message got error: {:?}", e);
-                return Err(ProducerError::Connection(e).into());
-            }
-        };
+        }
 
         error!(
             "send_message: connection {} disconnected, reconnecting producer for topic: {}",

--- a/src/retry_op.rs
+++ b/src/retry_op.rs
@@ -26,6 +26,8 @@ pub async fn handle_retry_error<Exe: Executor>(
                 proto::ServerError::ServiceNotReady
                     | proto::ServerError::ConsumerBusy
                     | proto::ServerError::ProducerBusy
+                    | proto::ServerError::ProducerBlockedQuotaExceededError
+                    | proto::ServerError::ProducerBlockedQuotaExceededException
             ) =>
         {
             (


### PR DESCRIPTION
Fixes #400

## Summary

- Check `connection.is_valid()` at the top of the `send_message` loop. If the connection
  is poisoned, fall through to existing reconnection logic instead of sending into a dead
  connection.
- Add `ProducerBlockedQuotaExceededError` and `ProducerBlockedQuotaExceededException`
  to retryable errors in `handle_retry_error`, so producer recreation retries with
  backoff when the broker rejects due to quota.

## Context

When the broker silently blocks sends (e.g. backlog quota with `block_if_queue_full`),
the producer enters an infinite timeout loop because `sender().send()` succeeds
(the channel is still open) but the receipt never arrives. The existing reconnection
logic only triggers on immediate send failure, never on receipt timeout.

`ConsumerEngine` already handles this correctly by checking `is_valid()` — this PR
applies the same pattern to the producer.

## Test plan

- Tested against a Pulsar 2.6.4 broker with backlog quota and `block_if_queue_full` enabled
- Producer now detects poisoned connection, reconnects, and retries creation with
  backoff until quota is freed
- When quota is released, the producer recreates successfully and resumes sending

---

_Co-authored with [Claude Code](https://claude.com/claude-code)._