### PR TITLE
Add public constructor to consumer::Message<T> to improve testability

### DIFF
--- a/src/consumer/message.rs
+++ b/src/consumer/message.rs
@@ -21,6 +21,15 @@ pub struct Message<T> {
 }
 
 impl<T> Message<T> {
+    pub fn new(topic: &str, message_id: MessageData, payload: Payload) -> Self {
+        Message {
+            topic: topic.to_string(),
+            message_id,
+            payload,
+            _phantom: PhantomData,
+        }
+    }
+
     /// Pulsar metadata for the message
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn metadata(&self) -> &MessageMetadata {

--- a/src/consumer/topic.rs
+++ b/src/consumer/topic.rs
@@ -296,15 +296,11 @@ impl<T: DeserializeMessage, Exe: Executor> TopicConsumer<T, Exe> {
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     fn create_message(&self, message_id: MessageIdData, payload: Payload) -> Message<T> {
-        Message {
-            topic: self.topic.clone(),
-            message_id: MessageData {
-                id: message_id,
-                batch_size: payload.metadata.num_messages_in_batch,
-            },
-            payload,
-            _phantom: PhantomData,
-        }
+        let message_id = MessageData {
+            id: message_id,
+            batch_size: payload.metadata.num_messages_in_batch,
+        };
+        Message::new(&self.topic, message_id, payload)
     }
 
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]


### PR DESCRIPTION
This fixes https://github.com/streamnative/pulsar-rs/issues/367 by providing a public constructor for consumer::Message<T>.

As all of the fields except _phantom were public, this should be a very very minor increase in public API surface area, but lets write tests like:

```
                    message: Message::<MessagePayload>::new(
                        &"",
                        MessageData {
                            id: MessageIdData::default(),
                            batch_size: None,
                        },
                        pulsar::Payload {
                            metadata: pulsar::message::Metadata::default(),
                            data: delivery.encode_to_vec(),
                        },
                    ),
```
and have it compile.