### PR TITLE
fix: Deny reader creation for partitioned topics

### DIFF
--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -118,7 +118,8 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
         self
     }
 
-    /// Interval for refreshing the topics when using a topic regex or when errors occur with a MultiTopicConsumer
+    /// Interval for refreshing the topics when using a topic regex or when errors occur with a
+    /// MultiTopicConsumer
     #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
     pub fn with_topic_refresh(mut self, refresh_interval: Duration) -> Self {
         self.topic_refresh = Some(refresh_interval);
@@ -331,9 +332,9 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
         warn!("Subscription Type for a reader is `Exclusive`. Resetting.");
         config.sub_type = SubType::Exclusive;
 
-        if self.topics.unwrap().len() > 1 {
+        if joined_topics.len() > 1 {
             return Err(Error::Custom(
-                "Unable to create a reader - one topic max".to_string(),
+                "Unable to create a reader - one topic partition max".to_string(),
             ));
         }
 


### PR DESCRIPTION
Right now during reader creation it validates and deny's multi topics via https://github.com/streamnative/pulsar-rs/blob/86fda8893855af0f9d29f72782af7c1aa61adc7d/src/consumer/builder.rs#L334

but this catch fails to account for partitioned topics which returns multiple `joined_topics`. This creates unpredictable behavior at https://github.com/streamnative/pulsar-rs/blob/86fda8893855af0f9d29f72782af7c1aa61adc7d/src/consumer/builder.rs#L340 since it will choose the first partition randomly depending on how its returned by the broker during lookup.

This change changes the validation of topic len on `joined_topics.len()` instead of `self.topics` to prevent unpredictable behavior. 

If we want to support partitioned topics in `pulsar-rs` I can draft up a separate PR that internally changes the `Reader` to hold a `InnerConsumer` to account for partitioned topics 