### PR TITLE
fix: silence pulsar warnings under no-compression feature sets

### DIFF
--- a/src/consumer/engine.rs
+++ b/src/consumer/engine.rs
@@ -437,8 +437,18 @@ impl<Exe: Executor> ConsumerEngine<Exe> {
     async fn process_payload(
         &mut self,
         message: CommandMessage,
-        mut payload: Payload,
+        payload: Payload,
     ) -> Result<(), Error> {
+        // Only the compression arms below mutate `payload`; without any of those
+        // features the binding stays immutable, so gate the `mut` to avoid an
+        // `unused_mut` warning.
+        #[cfg(any(
+            feature = "lz4",
+            feature = "flate2",
+            feature = "zstd",
+            feature = "snap"
+        ))]
+        let mut payload = payload;
         let compression = match payload.metadata.compression {
             None => proto::CompressionType::None,
             Some(compression) => proto::CompressionType::try_from(compression).map_err(|err| {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,7 +1,6 @@
 //! Message publication
 use std::{
     collections::{btree_map::Entry, BTreeMap, HashMap, VecDeque},
-    io::Write,
     pin::Pin,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -832,9 +831,19 @@ impl<Exe: Executor> TopicProducer<Exe> {
 
 #[cfg_attr(feature = "telemetry", tracing::instrument(skip_all))]
 fn compress_message(
-    mut message: ProducerMessage,
+    message: ProducerMessage,
     compression: &Option<Compression>,
 ) -> Result<ProducerMessage, Error> {
+    // Only the compression arms below mutate `message`; without any of those
+    // features the binding stays immutable, so gate the `mut` to avoid an
+    // `unused_mut` warning.
+    #[cfg(any(
+        feature = "lz4",
+        feature = "flate2",
+        feature = "zstd",
+        feature = "snap"
+    ))]
+    let mut message = message;
     let compressed_message = match compression {
         None | Some(Compression::None) => message,
         #[cfg(feature = "lz4")]
@@ -850,6 +859,8 @@ fn compress_message(
         }
         #[cfg(feature = "flate2")]
         Some(Compression::Zlib(compression)) => {
+            use std::io::Write;
+
             let mut e = flate2::write::ZlibEncoder::new(Vec::new(), compression.level);
             e.write_all(&message.payload[..])
                 .map_err(ProducerError::Io)?;
@@ -871,6 +882,8 @@ fn compress_message(
         }
         #[cfg(feature = "snap")]
         Some(Compression::Snappy(..)) => {
+            use std::io::Write;
+
             let mut compressed_payload = Vec::new();
             {
                 let mut encoder = snap::write::FrameEncoder::new(&mut compressed_payload);


### PR DESCRIPTION
## Problem

Building the `pulsar` crate **without** the `compression` feature — e.g.

```
cargo clippy -p pulsar --no-default-features --features tokio-runtime -- -D warnings
```

produces three warnings that are masked under the default feature set (which enables `compression`):

- `src/producer.rs` — unused `io::Write` import
- `src/producer.rs` — unnecessary `mut` on `compress_message`'s `message` parameter
- `src/consumer/engine.rs` — unnecessary `mut` on `process_payload`'s `payload` parameter

CI stays green today because both clippy jobs enable `compression`, but the warnings surface for any downstream build that depends on `pulsar` with `default-features = false` and no compression features.

## Fix

Gate the import and the two `mut` bindings on the individual compression sub-features (`lz4`/`flate2`/`zstd`/`snap`) that actually use them — rather than the umbrella `compression` feature — so the crate is warning-free across **every** feature combination, including single-sub-feature builds like `--features lz4`, without changing behavior under any feature.

`io::Write` is moved out of the module-level `use` block into the `flate2`/`snap` match arms (the only two that call `write_all`), matching the existing `use std::io::Read;` convention already used for decompression in `engine.rs`.

No behavior change: under a no-compression build the only reachable `match` arm moves the message/payload without mutating it, so the `mut` is genuinely unused there.

## Verification

- `cargo clippy -p pulsar --no-default-features --features tokio-runtime -- -D warnings` — now clean (previously 3 warnings)
- `cargo clippy -p pulsar --features telemetry -- -D warnings` — clean (compression-on path)
- `cargo fmt --all --check` — clean
